### PR TITLE
Associate a timestamp to pulled packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /Cargo.lock
 /target/
 *.bin
+*#*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itm-decode"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
         "Viktor Sonesten <v@tmplt.dev>",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1338,4 +1338,137 @@ mod tests {
             assert_eq!(decoder.pull(), Ok(Some(packet.clone())));
         }
     }
+
+    #[test]
+    fn pull_with_timestamp() {
+        let mut decoder = Decoder::new();
+        #[rustfmt::skip]
+        decoder.feed([
+            // PC sample (sleeping)
+            0b0001_0101,
+            0b0000_0000,
+
+            // PC sample (sleeping)
+            0b0001_0101,
+            0b0000_0000,
+
+            // PC sample (sleeping)
+            0b0001_0101,
+            0b0000_0000,
+
+            // GTS1
+            0b1001_0100,
+            0b1000_0000,
+            0b1010_0000,
+            0b1000_0100,
+            0b0000_0000,
+
+            // GTS2 (48-bit)
+            0b1011_0100,
+            0b1011_1101,
+            0b1111_0100,
+            0b1001_0001,
+            0b0000_0001,
+
+            // LTS1
+            0b1100_0000,
+            0b1100_1001,
+            0b0000_0001,
+
+            // Pull!
+
+            // PC sample (sleeping)
+            0b0001_0101,
+            0b0000_0000,
+
+            // LTS1
+            0b1100_0000,
+            0b1100_1001,
+            0b0000_0001,
+
+            // Pull!
+
+            // Overflow
+            0b0111_0000,
+
+            // LTS1
+            0b1100_0000,
+            0b1100_1001,
+            0b0000_0001,
+
+            // Pull!
+
+            // GTS1
+            0b1001_0100,
+            0b1000_0000,
+            0b1010_0000,
+            0b1000_0100,
+            0b0000_0000,
+
+            // GTS2 (48-bit)
+            0b1011_0100,
+            0b1011_1101,
+            0b1111_0100,
+            0b1001_0001,
+            0b0000_0001,
+
+            // LTS1
+            0b1111_0000,
+            0b1100_1001,
+            0b0000_0001,
+
+            // Pull!
+
+            // Pull!
+        ].to_vec());
+
+        for set in [
+            Ok(Some((
+                [
+                    TracePacket::PCSample { pc: None },
+                    TracePacket::PCSample { pc: None },
+                    TracePacket::PCSample { pc: None },
+                ]
+                .into(),
+                Timestamp {
+                    base: Some((0b1_0010001_1110100_0111101 << 26) | (0b0_0000100_0100000_0000000)),
+                    delta: Some(0b1_1001001),
+                    data_relation: Some(TimestampDataRelation::Sync),
+                    diverged: false,
+                },
+            ))),
+            Ok(Some((
+                [TracePacket::PCSample { pc: None }].into(),
+                Timestamp {
+                    base: Some((0b1_0010001_1110100_0111101 << 26) | (0b0_0000100_0100000_0000000)),
+                    delta: Some(0b1_1001001 * 2),
+                    data_relation: Some(TimestampDataRelation::Sync),
+                    diverged: false,
+                },
+            ))),
+            Ok(Some((
+                [TracePacket::Overflow].into(),
+                Timestamp {
+                    base: Some((0b1_0010001_1110100_0111101 << 26) | (0b0_0000100_0100000_0000000)),
+                    delta: Some(0b1_1001001 * 3),
+                    data_relation: Some(TimestampDataRelation::Sync),
+                    diverged: true,
+                },
+            ))),
+            Ok(Some((
+                [].into(),
+                Timestamp {
+                    base: Some((0b1_0010001_1110100_0111101 << 26) | (0b0_0000100_0100000_0000000)),
+                    delta: Some(0b1_1001001),
+                    data_relation: Some(TimestampDataRelation::UnknownAssocEventDelay),
+                    diverged: false,
+                },
+            ))),
+            Ok(None),
+        ]
+        .iter()
+        {
+            assert_eq!(decoder.pull_with_timestamp(), *set);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,9 +625,12 @@ impl Decoder {
 
             // Do we have enough info two calculate a new base for the timestamp?
             if let (Some(lower), Some(upper)) = (self.ts_ctx.gts1, self.ts_ctx.gts2) {
-                const GTS2_TS_SHIFT: usize = 25; // see (Appendix D4.2.5).
+                // XXX Should we move this calc into some Timestamp::from()?
+                const GTS2_TS_SHIFT: usize = 26; // see (Appendix D4.2.5).
                 self.ts_ctx.ts = Timestamp::default();
                 self.ts_ctx.ts.base = Some((upper << GTS2_TS_SHIFT) | lower);
+                self.ts_ctx.gts1 = None;
+                self.ts_ctx.gts2 = None;
             }
         }
     }


### PR DESCRIPTION
This PR adds `Decoder::pull_with_timestamp` that associate a timestamp structure to a set of data packets. Local timestamps will monotonically increase a delta timestamp counter. Global timestamps will update a base timestamp, and reset the delta to zero, when `pull`ed from the bitstream.