### PR TITLE
replace inline exception enum with VectActive enum from cortex_m

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ homepage = "https://github.com/tmplt/itm-decode"
 bitmatch = "0.1.1"
 bitvec = "0.19.4"
 funty = "=1.1.0"
+cortex-m = { version = "0.6", default-features = false }
 
 # only required by itm-decode executable
 anyhow = { version = "1.0", optional = true }


### PR DESCRIPTION
Table B1-4 is already defined in cortex_m::peripheral::scb::Exception,
with a wrapping VectActive enum that handles ThreadMode and interrupts.

Resolves #11.

